### PR TITLE
add $wgPiwikJSFileURL, $wgPiwikPHPFileURL

### DIFF
--- a/Piwik.php
+++ b/Piwik.php
@@ -39,4 +39,5 @@ $GLOBALS['wgPiwikActionName'] = "";
 $GLOBALS['wgPiwikDisableCookies'] = false;
 $GLOBALS['wgPiwikProtocol'] = 'auto';
 $GLOBALS['wgPiwikUsernameCustomVariable'] = array();
+$GLOBALS['wgPiwikJSFileURL'] = null;
 


### PR DESCRIPTION
Hello,

Setting these globals in a configuration removes the constraint of having to host piwik.js on the same domain as piwik.php. This is needed for those who want to host piwik.js on a CDN.

For instance, on [Vikidia](http://vikidia.org), we have Piwik on _stats.vikidia.org_ and our host's CDN on _download.vikidia.org_. Without this commit, there seems to be no way to use piwik.js on _download_ while piwik.php lives on _stats_.

Both variables take precedence over `$wgPiwikURL`. `$wgPiwikURL` is still used when only one of them is defined. Thus, for our CDN use-case, we only had to define `$wgPiwikJSFileURL` in our configuration file:

``` php
$wgPiwikURL = 'stats.vikidia.org';
$wgPiwikJSFileURL = 'download.vikidia.org/piwik.js';
```

I based my changes on [this Piwik forum thread](http://forum.piwik.org/read.php?2,112345,page=1), which ends with:

> Looking good!
> Cheers,
> Matt, Piwik founder

and everything seems to work with this patch on Vikidia too.

Thank you for this nice extension, it eased a lot our removal of Google Analytics.
