### PR TITLE
SECURITY: XSS when $wgPiwikTrackUsernames is true

### DIFF
--- a/Piwik.hooks.php
+++ b/Piwik.hooks.php
@@ -82,8 +82,8 @@ class PiwikHooks {
         // name for anonymous visitors is their IP address which Piwik already
         // records.
         if ($wgPiwikTrackUsernames && $wgUser->isLoggedIn()) {
-            $username = $wgUser->getName();
-            $customJs .= PHP_EOL . "  _paq.push(['setUserId','{$username}']);";
+            $username = Xml::encodeJsVar( $wgUser->getName() );
+            $customJs .= PHP_EOL . "  _paq.push([\"setUserId\",{$username}]);";
         }
 
 		// Check if server uses https


### PR DESCRIPTION
With a specially-crafted username like 0'+(window.alert('You have been hacked'))+'0 the user receives the alert "You have been hacked". This commit escapes the username.