### PR TITLE
Convert to extension registration

### DIFF
--- a/Piwik.hooks.php
+++ b/Piwik.hooks.php
@@ -82,8 +82,8 @@ class PiwikHooks {
         // name for anonymous visitors is their IP address which Piwik already
         // records.
         if ($wgPiwikTrackUsernames && $wgUser->isLoggedIn()) {
-            $username = $wgUser->getName();
-            $customJs .= PHP_EOL . "  _paq.push(['setUserId','{$username}']);";
+            $username = Xml::encodeJsVar( $wgUser->getName() );
+            $customJs .= PHP_EOL . "  _paq.push([\"setUserId\",{$username}]);";
         }
 
 		// Check if server uses https

--- a/Piwik.hooks.php
+++ b/Piwik.hooks.php
@@ -26,7 +26,7 @@ class PiwikHooks {
 			   $wgPiwikIgnoreBots, $wgUser, $wgScriptPath, 
 			   $wgPiwikCustomJS, $wgPiwikActionName, $wgPiwikUsePageTitle,
 			   $wgPiwikDisableCookies, $wgPiwikProtocol,
-         $wgPiwikTrackUsernames;
+			   $wgPiwikTrackUsernames, $wgPiwikJSFileURL;
 		
 		// Is piwik disabled for bots?
 		if ( $wgUser->isAllowed( 'bot' ) && $wgPiwikIgnoreBots ) {
@@ -100,6 +100,18 @@ class PiwikHooks {
 		// Prevent XSS
 		$wgPiwikFinalActionName = Xml::encodeJsVar( $wgPiwikFinalActionName );
 		
+		// If $wgPiwikJSFileURL is null the locations are $wgPiwikURL/piwik.php and $wgPiwikURL/piwik.js
+		// Else they are $wgPiwikURL/piwik.php and $wgPiwikJSFileURL
+		$jsPiwikURL = '';
+		$jsPiwikURLCommon = '';
+		if( is_null( $wgPiwikJSFileURL ) ) {
+			$wgPiwikJSFileURL = 'piwik.js';
+			$jsPiwikURLCommon = '+' . Xml::encodeJsVar( $wgPiwikURL . '/' );
+		} else {
+			$jsPiwikURL = '+' . Xml::encodeJsVar( $wgPiwikURL . '/' );
+		}
+		$jsPiwikJSFileURL = Xml::encodeJsVar( $wgPiwikJSFileURL );
+
 		// Piwik script
 		$script = <<<PIWIK
 <!-- Piwik -->
@@ -109,11 +121,11 @@ class PiwikHooks {
   _paq.push(["enableLinkTracking"]);
 
   (function() {
-    var u=(("https:" == document.location.protocol) ? "https" : "http") + "://{$wgPiwikURL}/";
-    _paq.push(["setTrackerUrl", u+"piwik.php"]);
+    var u = (("https:" == document.location.protocol) ? "https" : "http") + "://"{$jsPiwikURLCommon};
+    _paq.push(["setTrackerUrl", u{$jsPiwikURL}+"piwik.php"]);
     _paq.push(["setSiteId", "{$wgPiwikIDSite}"]);
     var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0]; g.type="text/javascript";
-    g.defer=true; g.async=true; g.src=u+"piwik.js"; s.parentNode.insertBefore(g,s);
+    g.defer=true; g.async=true; g.src=u+{$jsPiwikJSFileURL}; s.parentNode.insertBefore(g,s);
   })();
 </script>
 <!-- End Piwik Code -->

--- a/Piwik.php
+++ b/Piwik.php
@@ -39,4 +39,5 @@ $GLOBALS['wgPiwikActionName'] = "";
 $GLOBALS['wgPiwikDisableCookies'] = false;
 $GLOBALS['wgPiwikProtocol'] = 'auto';
 $GLOBALS['wgPiwikUsernameCustomVariable'] = array();
+$GLOBALS['wgPiwikJSFileURL'] = null;
 

--- a/Piwik.php
+++ b/Piwik.php
@@ -12,32 +12,14 @@
  * @package Extensions
  */
 
-if ( !defined( 'MEDIAWIKI' ) ) die( 'This file is a MediaWiki extension, it is not a valid entry point' );
-
-$GLOBALS['wgExtensionCredits']['other'][] = array(
-	'path'           => __FILE__,
-	'name'           => 'Piwik Integration',
-	'version'        => '2.4.2',
-	'author'         => array('Isb1009', '[http://www.daschmedia.de DaSch]', '[https://github.com/YOUR1 Youri van den Bogert]'),
-	'description'    => 'Adding Piwik Tracking Code',
-	'url'            => 'https://www.mediawiki.org/wiki/Extension:Piwik_Integration',
-);
-
-$dir = dirname(__FILE__) . '/';
-
-$GLOBALS['wgAutoloadClasses']['PiwikHooks'] = $dir . 'Piwik.hooks.php';
-
-$GLOBALS['wgHooks']['SkinAfterBottomScripts'][]  = 'PiwikHooks::PiwikSetup';
-
-$GLOBALS['wgPiwikIDSite'] = "";
-$GLOBALS['wgPiwikURL'] = "";
-$GLOBALS['wgPiwikIgnoreSysops'] = true;
-$GLOBALS['wgPiwikIgnoreBots'] = true;
-$GLOBALS['wgPiwikCustomJS'] = "";
-$GLOBALS['wgPiwikUsePageTitle'] = false;
-$GLOBALS['wgPiwikActionName'] = "";
-$GLOBALS['wgPiwikDisableCookies'] = false;
-$GLOBALS['wgPiwikProtocol'] = 'auto';
-$GLOBALS['wgPiwikUsernameCustomVariable'] = array();
-$GLOBALS['wgPiwikJSFileURL'] = null;
-
+if ( function_exists( 'wfLoadExtension' ) ) {
+	wfLoadExtension( 'Piwik' );
+	/* wfWarn(
+		'Deprecated PHP entry point used for Piwik extension. ' .
+		'Please use wfLoadExtension instead, ' .
+		'see https://www.mediawiki.org/wiki/Extension_registration for more details.'
+	); */
+	return true;
+} else {
+	die( 'This version of the Piwik extension requires MediaWiki 1.25+' );
+}

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,38 @@
+{
+	"name": "Piwik Integration",
+	"version": "3.0.0",
+	"author": [
+		"Isb1009",
+		"[http://www.daschmedia.de DaSch]",
+		"[https://github.com/YOUR1 Youri van den Bogert]"
+	],
+	"url": "https://www.mediawiki.org/wiki/Extension:Piwik_Integration",
+	"description": "Adding Piwik Tracking Code",
+	"license-name": "GPL-2.0+",
+	"type": "other",
+	"requires": {
+		"MediaWiki": ">= 1.25.0"
+	},
+	"config": {
+		"PiwikIDSite": "",
+		"PiwikURL": "",
+		"PiwikIgnoreSysops": true,
+		"PiwikIgnoreBots": true,
+		"PiwikCustomJS": "",
+		"PiwikUsePageTitle": false,
+		"PiwikActionName": "",
+		"PiwikDisableCookies": false,
+		"PiwikProtocol": "auto",
+		"PiwikUsernameCustomVariable": [],
+		"PiwikJSFileURL": null
+	},
+	"Hooks": {
+		"SkinAfterBottomScripts": [
+			"PiwikHooks::PiwikSetup"
+		]
+	},
+	"AutoloadClasses": {
+		"PiwikHooks": "Piwik.hooks.php"
+	},
+	"manifest_version": 1
+}


### PR DESCRIPTION
And require MediaWiki 1.25+ similarly to other extensions converted to extension registration.
Bump version to 3.0.0 given it breaks compatibility.

Bug: #15